### PR TITLE
Be more forgiving to paths on Windows

### DIFF
--- a/node-persist.js
+++ b/node-persist.js
@@ -259,7 +259,8 @@ var setOptions = function (userOptions) {
         }
 
         // dir is not absolute
-        if (options.dir[0] !== '/') {
+        options.dir = path.normalize(options.dir);
+        if (options.dir !== path.resolve(options.dir)) {
             options.dir = path.join(dir, "persist", options.dir);
             if (options.logging) {
                 console.log("Made dir absolute: " + options.dir);


### PR DESCRIPTION
Added a bit more checking to make sure options.dir gets resolved properly on Windows where paths may not have a leading forward slash.
