### PR TITLE
clean cached data on initalization

### DIFF
--- a/node-persist.js
+++ b/node-persist.js
@@ -84,6 +84,9 @@ exports.initSync = function (userOptions) {
         console.log(options);
     }
 
+    //remove cached data
+    data = {};
+
     //check to see if dir is present
     var exists = fs.existsSync(options.dir);
     if (exists) { //load data


### PR DESCRIPTION
I guess this is not a very common use-case, but I needed to initialize the library several times in order to load changes made by an external application to the cache files.
