### PR TITLE
added optional callback to setItem

### DIFF
--- a/node-persist.js
+++ b/node-persist.js
@@ -154,12 +154,12 @@ exports.valuesWithKeyMatch = function(match, callback) {
 /*
  * This function sets a key to a given value in the database.
  */
-exports.setItem = function (key, value) {
+exports.setItem = function (key, value, cb) {
     data[key] = value;
     if (options.interval) {
         changes[key] = true;
     } else if (options.continuous) {
-        exports.persistKey(key);
+        exports.persistKey(key, cb);
     }
     if (options.logging)
         console.log("set (" + key + ": " + value + ")");
@@ -226,9 +226,9 @@ exports.persistSync = function () {
 /*
  * This function triggers a key within the database to persist asynchronously.
  */
-exports.persistKey = function (key) {
+exports.persistKey = function (key, cb) {
     var json = options.stringify(data[key]);
-    fs.writeFile(path.join(options.dir, key), json, options.encoding);
+    fs.writeFile(path.join(options.dir, key), json, options.encoding, cb);
     changes[key] = false;
     if (options.logging)
         console.log("wrote: " + key);


### PR DESCRIPTION
i have a small program that uses [async](https://github.com/caolan/async)'s eachSeries( and eachLimit) helpers, and I am trying to persist the results to disk, both of these provide a callback, like a next() or done() when iteration is over, and I wanted to guarantee that each file is being persisted before the program exits.

with this change I can 

```
localStorage.setItem(key, json, next) 
```

Thanks
