### PR TITLE
Make ParseString exceptions return undefined

### DIFF
--- a/node-persist.js
+++ b/node-persist.js
@@ -301,7 +301,7 @@ var parseString = function(str){
         if(options.logging){
             console.log("parse error: ", e);
         }
-        return {};
+        return undefined;
     }
 };
 


### PR DESCRIPTION
If there's a problem parsing a persisted value, it seems more fitting to return `undefined` instead of an empty object (since we can persist things other than objects).

I came across this when an `undefined` variable was persisted to the filesystem.

Running `JSON.parse(undefined)` will throw an error, which caused this library to return an empty object rather than a falsy value.
