### PR TITLE
Fixed examples to have proper include pathing

### DIFF
--- a/examples/counter/counter.js
+++ b/examples/counter/counter.js
@@ -7,7 +7,7 @@
  * It will probably be incremented several times per page due to
  * multiple requests.
  */
-var storage = require('../../../node-persist');
+var storage = require('../../node-persist');
 var http = require('http');
 
 storage.initSync();

--- a/examples/highscores/highscores.js
+++ b/examples/highscores/highscores.js
@@ -3,7 +3,7 @@
  * Open up your browser to 'localhost:8080' to see it in action.
  */
 
- var storage = require('../../../node-persist');
+ var storage = require('../../node-persist');
  var express = require('express');
  var fs = require('fs');
 


### PR DESCRIPTION
When I would run 

```
node .\examples\counter\counter.js
```

I would get this error

```

module.js:340
    throw err;
          ^
Error: Cannot find module 'mkdirp'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (C:\nodetoys\node-persist.js:8:14)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```

This changes the reference of node-persist to be the proper directory
