### PR TITLE
userOptions directories no longer are sub directories under persist

### DIFF
--- a/node-persist.js
+++ b/node-persist.js
@@ -280,7 +280,7 @@ var setOptions = function (userOptions) {
         // dir is not absolute
         options.dir = path.normalize(options.dir);
         if (options.dir !== path.resolve(options.dir)) {
-            options.dir = path.join(dir, "persist", options.dir);
+            options.dir = path.join(dir, options.dir);
             if (options.logging) {
                 console.log("Made dir absolute: " + options.dir);
             }


### PR DESCRIPTION
When a user specifies any custom options the persist directory changes to ./persist/persist (or ./persist/customDir)
This change fixes that.

I'm slightly worried that I can't figure out why it was this way in the first place, thus its a separate pull request
