### PR TITLE
Use 'for of' instead of 'for in' when argument value is of type 'Array'

### DIFF
--- a/src/local-storage.js
+++ b/src/local-storage.js
@@ -131,8 +131,8 @@ LocalStorage.prototype = {
 
 	forEach: async function(callback) {
 		let data = await this.data();
-		for (let i in data) {
-			await callback(data[i]);
+		for (let d of data) {
+			await callback(d);
 		}
 	},
 
@@ -201,15 +201,15 @@ LocalStorage.prototype = {
 
 	removeExpiredItems: async function () {
 		let keys = await this.keys(isExpired);
-		for (let i in keys) {
-			await this.removeItem(keys[i]);
+		for (let key of keys) {
+			await this.removeItem(key);
 		}
 	},
 
 	clear: async function () {
 		let data = await this.data();
-		for (let i in data) {
-			await this.removeItem(data[i].key);
+		for (let d of data) {
+			await this.removeItem(d.key);
 		}
 	},
 
@@ -245,8 +245,7 @@ LocalStorage.prototype = {
 							return reject(err);
 						}
 						let data = [];
-						for (let i in arr) {
-							let currentFile = arr[i];
+						for (let currentFile of arr) {
 							if (currentFile[0] !== '.') {
 								data.push(await this.readFile(path.join(this.options.dir, currentFile)));
 							}


### PR DESCRIPTION
# 1. for in -> for of

**Change it to `for of` only if the argument of `for in` is of type Array.**


**Problem:** Add custom `Array` prototype
```javascript
Array.prototype.test = function() {
    return 'test'
}
```

```
TypeError: Data must be a string or a buffer
```

**Reason:**  [loop will iterate over all enumerable properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in)
```javascript
let arr = [1,2]

for (let i in arr) {
    console.log(arr[i]) // returns 1, 2
}

Array.prototype.test = function() {}

for (let i in arr) {
    console.log(arr[i]) // returns 1, 2, ƒ () {}
}
```

**Solution 1:** [hasOwnProperty](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty)
```javascript
let arr = [1,2]

Array.prototype.test = function() {}

for (let i in arr) {
    if (arr.hasOwnProperty(i)) {
        console.log(arr[i]) // returns 1, 2
    }
}
```
**Solution 2:** [for of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of)
```javascript
let arr = [1,2]

Array.prototype.test = function() {}

for (let i of arr) {
    console.log(i) // returns 1, 2
}
```


## 1.1. [node-persist.js](https://github.com/simonlast/node-persist/blob/master/src/node-persist.js)

### 1.1.1. mixin()
- `source` is `object` type. 
    - `nodePersist.create()` return `object`

**Therefore, it does not change.**

## 1.2. [local-storage](https://github.com/simonlast/node-persist/blob/master/src/local-storage.js)

### 1.2.1. LocalStorage.setOptions()
- `const defaults = {...}` line:13

**Therefore, it does not change.**

### 1.2.2. LocalStorage.forEach()
- `data` is `Array` type.
    - `this.data()` <- `this.readDirectory()`
        - `this.readDirectory()` return `Array`

**So change it to `for of`.**

### 1.2.3. LocalStorage.removeExpiredItems()
- `keys` is `Array` type.
    - `this.keys()` return [map](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Array/map)(`Array`)

**So change it to `for of`.**

### 1.2.4. LocalStorage.clear()
- `data` is `Array` type.
    - `this.data()` <- `this.readDirectory()`
        - `this.readDirectory()` return `Array`

**So change it to `for of`.**\

### 1.2.5. LocalStorage.readDirectory()
- `arr` is `Array` type.
    - [`fs.readdir`](<string[]> ) return `Array`(`<string[]>`)