### PR TITLE
Use fs.mkdir instead of mkdirp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-persist",
-  "version": "3.0.1",
+  "version": "3.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13,12 +13,14 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -59,7 +61,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "debug": {
       "version": "3.1.0",
@@ -181,12 +184,14 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }

--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
   ],
   "license": "MIT",
   "readmeFilename": "README.md",
-  "dependencies": {
-    "mkdirp": "~0.5.1"
-  },
   "devDependencies": {
     "chai": "^4.1.2",
     "mocha": "^5.0.5",

--- a/src/local-storage.js
+++ b/src/local-storage.js
@@ -6,7 +6,6 @@
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
-const mkdirp = require('mkdirp');
 const pkg = require('../package.json');
 
 const defaults = {
@@ -257,7 +256,7 @@ LocalStorage.prototype = {
 					return resolve(result);
 				} else {
 					//create the directory
-					mkdirp(dir, (err) => {
+					fs.mkdir(dir, { recursive: true }, (err) => {
 						if (err) {
 							return reject(err);
 						}

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,7 +1,6 @@
 
 const path = require('path');
 const fs = require('fs');
-const mkdirp = require('mkdirp');
 const assert = require('chai').assert;
 const rmdir = require('rimraf');
 
@@ -25,7 +24,7 @@ process.on('unhandledRejection', (reason, p) => {
 describe('node-persist ' + pkg.version + ' tests:', async function() {
 
 	before(function(done) {
-		mkdirp(TEST_BASE_DIR, done);
+		fs.mkdir(TEST_BASE_DIR, {recursive: true}, done);
 	});
 
 	after(function(done) {
@@ -291,7 +290,7 @@ describe('node-persist ' + pkg.version + ' tests:', async function() {
 			let storage = nodePersist.create();
 
 			// make sure the dir is there, and write a random file in there
-			mkdirp.sync(dir);
+			fs.mkdirSync(dir, {recursive: true});
 			fs.writeFileSync(dir + '/foo.bar', 'nothing that makes sense');
 
 			try {
@@ -308,7 +307,7 @@ describe('node-persist ' + pkg.version + ' tests:', async function() {
 			let storage = nodePersist.create();
 
 			// make sure the dir is there, and write a random file in there
-			mkdirp.sync(dir);
+			fs.mkdirSync(dir, {recursive: true});
 			fs.writeFileSync(dir + '/foo.bar', 'nothing that makes sense');
 
 			await storage.init({


### PR DESCRIPTION
This removes the dependency on `mkdirp` and just uses `fs.mkdir` since it now can work recursively.

Tests pass locally!

Fixes #123 