### PR TITLE
Doc: Remove sync example from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,8 @@ $ npm install node-persist
 ```js
 const storage = require('node-persist');
 
-//you must first call storage.init or initSync
-storage.initSync( /* options ... */ );
-// or 
-// storage.init( /* options ... */ );
+// you must first call storage.init
+await storage.init( /* options ... */ );
 
 // then anywhere else in your code
 await storage.setItem('name','yourname')


### PR DESCRIPTION
3.0.0 Changelong entry sais that all the `*Sync` functions were removed