### PR TITLE
Throw an error if users try to initialise LocalStorage or global instance more than once

### DIFF
--- a/src/local-storage.js
+++ b/src/local-storage.js
@@ -80,7 +80,7 @@ LocalStorage.prototype = {
 
 	init: async function (options) {
 		if (this.initialised) {
-			throw new Error("node-persist has already been initialised, did you call init or initSync twice?")
+			throw new Error("LocalStorage has already been initialised, did you call init or initSync twice?")
 		}
 		this.initialised = true
 
@@ -98,7 +98,7 @@ LocalStorage.prototype = {
 
 	initSync: function (options) {
 		if (this.initialised) {
-			throw new Error("node-persist has already been initialised, did you call init or initSync twice?")
+			throw new Error("LocalStorage has already been initialised, did you call init or initSync twice?")
 		}
 		this.initialised = true
 

--- a/src/local-storage.js
+++ b/src/local-storage.js
@@ -79,6 +79,11 @@ const LocalStorage = function (options) {
 LocalStorage.prototype = {
 
 	init: async function (options) {
+		if (this.initialised) {
+			throw new Error("node-persist has already been initialised, did you call init or initSync twice?")
+		}
+		this.initialised = true
+
 		if (options) {
 			this.setOptions(options);
 		}
@@ -92,6 +97,11 @@ LocalStorage.prototype = {
 	},
 
 	initSync: function (options) {
+		if (this.initialised) {
+			throw new Error("node-persist has already been initialised, did you call init or initSync twice?")
+		}
+		this.initialised = true
+
 		if (options) {
 			this.setOptions(options);
 		}

--- a/src/node-persist.js
+++ b/src/node-persist.js
@@ -21,6 +21,9 @@ const LocalStorage = require('./local-storage');
      * An options hash can be optionally passed.
      */
     nodePersist.init = async function (userOptions) {
+        if (nodePersist.defaultInstance) {
+            throw new Error('node-persist has already been initialized')
+        }
         const localStorage = nodePersist.defaultInstance = nodePersist.create(userOptions);
         let ret = await localStorage.init(userOptions);
         mixin(nodePersist, localStorage, {skip: ['init', 'create']});

--- a/tests/index.js
+++ b/tests/index.js
@@ -150,7 +150,11 @@ describe('node-persist ' + pkg.version + ' tests:', async function() {
 			writeQueue: true,
 			writeQueueWriteOnlyLast: true
 		};
-		let storage = nodePersist.create();
+		let storage;
+		beforeEach(async () => {
+			storage = nodePersist.create();
+			await storage.init(options);
+		})
 
 		let items = {
 			'item1': 1,
@@ -264,9 +268,10 @@ describe('node-persist ' + pkg.version + ' tests:', async function() {
 			let options = {
 				dir: randDir()
 			};
-			let storage = nodePersist.create();
+			let storage;
 
 			beforeEach(async function() {
+				storage = nodePersist.create();
 				await storage.init(options);
 				await storage.setItem('item1', items.item1);
 				await storage.setItem('item2', items.item2);

--- a/tests/index.js
+++ b/tests/index.js
@@ -31,6 +31,39 @@ describe('node-persist ' + pkg.version + ' tests:', async function() {
 		rmdir(TEST_BASE_DIR, done);
 	});
 
+	describe('default instance', function() {
+		this.beforeEach(() => {
+			// Reset global state
+			nodePersist.defaultInstance = null;
+		})
+
+		it('should create the default instance of LocalStorage sync and use it', async function() {
+			await nodePersist.init({dir: randDir()});
+			assert.ok(nodePersist.defaultInstance instanceof LocalStorage);
+			await nodePersist.setItem('item8877', 'hello');
+			assert.equal(await nodePersist.getItem('item8877'), 'hello', `write/read didn't work`);
+		});
+
+		it('should create a default instance', async function() {
+			let dir = randDir();
+			let options = await nodePersist.init({dir: dir});
+			assert.equal(options.dir, dir, `Options don't match`);
+		});
+
+		it('should not allow init to be called more than once', async function() {
+			await nodePersist.init();
+
+      let initError;
+      try {
+        await nodePersist.init();
+      } catch(err) {
+        initError = err
+      }
+
+      assert.include(initError != null ? initError.message : '', 'node-persist has already been initialized');
+		});
+	})
+
 	describe('instances', function() {
 		let dir1, dir2, storage1, storage2, storage11, storage22, storageSync;
 
@@ -85,19 +118,6 @@ describe('node-persist ' + pkg.version + ' tests:', async function() {
 			await storageSync.setItem('item9977', 'hello');
 			assert.equal(await storageSync.getItem('item9977'), 'hello', `write/read didn't work`);
 		});
-
-		it('should create the default instance of LocalStorage sync and use it', async function() {
-			await nodePersist.init({dir: randDir()});
-			assert.ok(nodePersist.defaultInstance instanceof LocalStorage);
-			await nodePersist.setItem('item8877', 'hello');
-			assert.equal(await nodePersist.getItem('item8877'), 'hello', `write/read didn't work`);
-		});
-
-		it('should create a default instance', async function() {
-			let dir = randDir();
-			let options = await nodePersist.init({dir: dir});
-			assert.equal(options.dir, dir, `Options don't match`);
-		});
 	});
 
 	describe('initialisation', function() {
@@ -135,12 +155,12 @@ describe('node-persist ' + pkg.version + ' tests:', async function() {
 				initError = err
 			}
 
-			assert.include(initError != null ? initError.message : '', 'node-persist has already been initialised');
+			assert.include(initError != null ? initError.message : '', 'LocalStorage has already been initialised');
 
 			assert.throws(() => {
 				storage.initSync(options)
-			}, 'node-persist has already been initialised', undefined, 'initSync() should throw an error when called after init()');
-		})
+			}, 'LocalStorage has already been initialised', undefined, 'initSync() should throw an error when called after init()');
+		});
 	})
 
 	describe('operations', function() {

--- a/tests/index.js
+++ b/tests/index.js
@@ -100,6 +100,49 @@ describe('node-persist ' + pkg.version + ' tests:', async function() {
 		});
 	});
 
+	describe('initialisation', function() {
+		let options = {
+			dir: randDir(),
+			// logging: true,
+			writeQueue: true,
+			writeQueueWriteOnlyLast: true
+		};
+
+		let storage;
+		beforeEach(async () => {
+			storage = nodePersist.create();
+		})
+
+		it('should init()', async function() {
+			await storage.init(options);
+			assert.equal(storage.options.dir, options.dir);
+			assert.ok(fs.existsSync(options.dir));
+		});
+
+		it('should initSync()', async function() {
+			storage.initSync(options);
+			assert.equal(storage.options.dir, options.dir);
+			assert.ok(fs.existsSync(options.dir));
+		});
+
+		it('should fail if init() or initAsync() are called more than once per instance', async function() {
+			await storage.init(options);
+
+			let initError;
+			try {
+				await storage.init(options);
+			} catch(err) {
+				initError = err
+			}
+
+			assert.include(initError != null ? initError.message : '', 'node-persist has already been initialised');
+
+			assert.throws(() => {
+				storage.initSync(options)
+			}, 'node-persist has already been initialised', undefined, 'initSync() should throw an error when called after init()');
+		})
+	})
+
 	describe('operations', function() {
 		let options = {
 			dir: randDir(),
@@ -126,17 +169,6 @@ describe('node-persist ' + pkg.version + ' tests:', async function() {
 		let generatedItemsKeys = Object.keys(generatedItems);
 
 		describe('general items operations', function() {
-			it('should init()', async function() {
-				await storage.init(options);
-				assert.equal(storage.options.dir, options.dir);
-				assert.ok(fs.existsSync(options.dir));
-			});
-
-			it('should initSync()', function() {
-				storage.initSync(options);
-				assert.equal(storage.options.dir, options.dir);
-				assert.ok(fs.existsSync(options.dir));
-			});
 
 			it('should setItem()', async function() {
 				await storage.setItem('item1', items.item1);


### PR DESCRIPTION
This change throws an error if a single instance of `LocalStorage` or the global instance is initialised more than once. This helps prevent accidentally initialising either multiple times, which I believe is not intended to be supported and, for the global instance, causes a resource leak.

We had a problem in our app where CPU usage would slowly climb over time and eventually lock up the server. We found the global node-persist `init` was being called in a function that was itself being called many times per request. While `LocalStorage` seems to be ok with `init` being called multiple times (but IMO shouldn't silently allow it), the global `init` creates a new `LocalStorage` instance every time it's called. If either write queues or expiry are enabled (they are by default), the new instances keep registering new interval callbacks and the old ones are not cancelled, preventing the old instances from being garbage collected and forcing node to process an increasing number of callbacks over time until eventually all CPU is consumed.